### PR TITLE
Added Option to Define Length of Original Episode Number

### DIFF
--- a/rename.bat
+++ b/rename.bat
@@ -18,8 +18,12 @@ if "%filePath%"=="" goto setfilepath
 set /p season="Enter Season Number: "
 if '%season%'=='' goto setseason
 
+:setepisodelength
+set /p epLength="Enter Length of Episode Numbering: "
+if "%epLength%"=="" goto setepisodelength
+
 :renameScript
-php rename.php "%filePath%" %season% %executeRename%
+php rename.php "%filePath%" %season% %executeRename% %epLength%
 
 :executerename
 if '%executeRename%'=='true' (

--- a/rename.php
+++ b/rename.php
@@ -39,8 +39,8 @@ foreach($files as $fileName) {
 	echo "Parsing: $fileName\n";
 	$firstInt = my_ofset($fileName, "0123456789");
 	$lastInt = $firstInt+$epLength;
-	echo "first int: $firstInt\n";
-	echo "last int: $lastInt\n";
+	//echo "first int: $firstInt\n";
+	//echo "last int: $lastInt\n";
 	
 	$strBeforeFirstInt = substr($fileName, 0, $firstInt);
 	$strAfterFirstInt = substr($fileName, $lastInt);

--- a/rename.php
+++ b/rename.php
@@ -6,6 +6,8 @@ if(!isset($argv[1])){
 	die("Must provide Season\n");
 } else if(!isset($argv[3]) || $argv[3] === "false") {
 	echo "Previewing Filename changes\n";
+} else if(!isset($argv[4])){
+	die("Must provide Original Episode Numbering Length\n");
 } else if($argv[3] === "true") {
 	$commitRename = true;
 	echo "Renaming Files...\n";
@@ -13,6 +15,7 @@ if(!isset($argv[1])){
 
 $season = str_pad($argv[2], 2, '0', STR_PAD_LEFT);
 $filePath = $argv[1];
+$epLength = $argv[4];
 echo "Renaming Season $season\n";
 
 
@@ -35,10 +38,12 @@ foreach($files as $fileName) {
 	
 	echo "Parsing: $fileName\n";
 	$firstInt = my_ofset($fileName, "0123456789");
-	//echo "first int: $firstInt\n";
+	$lastInt = $firstInt+$epLength;
+	echo "first int: $firstInt\n";
+	echo "last int: $lastInt\n";
 	
 	$strBeforeFirstInt = substr($fileName, 0, $firstInt);
-	$strAfterFirstInt = substr($fileName, $firstInt);
+	$strAfterFirstInt = substr($fileName, $lastInt);
 	$spaceAfterInt = strpos($strAfterFirstInt, ' ');
 	//echo "spaceAfterInt: $spaceAfterInt\n";
 	$episode = substr($strAfterFirstInt, 0, $spaceAfterInt);


### PR DESCRIPTION
Original code only replaced a single digit while re-naming, i.e. if the episode was 001, original code left the 001 in place.
Code does not allow or manual input of location of the first string position of episode number.*
Fix to detect episode numbering correctly is remaining.